### PR TITLE
Adding scoped translations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ $ rails generate csv_import_magic:controllers
 See our wiki page([I18n](https://github.com/Pagnet/csv_import_magic/wiki/I18n)).
 If your language not translated yet, send your yaml to append in our wiki, we appreciate your contribution.
 
+### Development
+
+To run tests you should first configure it's database and dependencies with:
+
+```console
+$ bundle install && bundle exec rake db:schema:load
+```
+
+Then run specs with:
+
+```console
+$ bundle exec rspec
+```
+
 ### CSV Importer
 
 CSV Import Magic is based on csv-importer. We encourage you to read more about csv-importer here:

--- a/app/models/importer.rb
+++ b/app/models/importer.rb
@@ -33,6 +33,10 @@ class Importer < ActiveRecord::Base
     source_klass.columns_names(name_of_parser.to_sym)
   end
 
+  def human_attribute_name(column, options = {})
+    I18n.translate(:"activemodel.attributes.#{source_klass.model_name.i18n_key}.csv_import_magic.#{column}", options.merge(default: source_klass.human_attribute_name(column)))
+  end
+
   private
 
   def set_parser
@@ -53,7 +57,7 @@ class Importer < ActiveRecord::Base
     return if columns_to_translate.blank?
 
     transalated_name_of_columns = columns_to_translate.map do |column|
-      source_klass.human_attribute_name(column)
+      human_attribute_name(column)
     end.to_sentence
 
     errors.add(:columns, I18n.t('errors.messages.missing', count: columns_to_translate.size, columns: transalated_name_of_columns))
@@ -70,7 +74,7 @@ class Importer < ActiveRecord::Base
 
     headers_to_translate = duplicate_headers.uniq
     headers_transalated = headers_to_translate.map do |header|
-      source_klass.human_attribute_name(header)
+      human_attribute_name(header)
     end.to_sentence
 
     errors.add(:columns, I18n.t('errors.messages.uniq', count: headers_to_translate.size, columns: headers_transalated))

--- a/app/services/csv_import_magic/importer.rb
+++ b/app/services/csv_import_magic/importer.rb
@@ -17,7 +17,7 @@ module CsvImportMagic
     end
 
     def column_separator
-      header = content.lines("\r")[0].gsub(/[^,;\t]/, '_')
+      header = content.lines[0].gsub(/[^,;\t]/, '_')
       header.scan(/[,;\t]/).first
     end
 

--- a/app/views/csv_import_magic/importers/edit.html.erb
+++ b/app/views/csv_import_magic/importers/edit.html.erb
@@ -1,4 +1,4 @@
-<% columns = @importer.importable_columns(@importer.parser).map { |column| [@importer.source_klass.human_attribute_name(column), column] }.unshift([t('csv_import_magic.views.importers.edit.ignore_column_label'), :ignore]) %>
+<% columns = @importer.importable_columns(@importer.parser).map { |column| [@importer.human_attribute_name(column), column] }.unshift([t('csv_import_magic.views.importers.edit.ignore_column_label'), :ignore]) %>
 
 <h3 class='page-title'>
   <%= t('csv_import_magic.views.importers.edit.title') %>
@@ -17,7 +17,7 @@
           </header>
 
           <% selected = columns.find { |c| c.join(' ').match(/#{header}/i) }.try(:last).presence || :ignore %>
-          <%= f.input "columns][", as: :select, collection: columns, label: false, hint: t('csv_import_magic.views.importers.edit.hint'), include_blank: false, selected: f.object.columns[i] || selected %>
+          <%= f.input "columns[]", as: :select, collection: columns, label: false, hint: t('csv_import_magic.views.importers.edit.hint'), include_blank: false, selected: f.object.columns[i] || selected %>
 
           <header class="examples"><%= t('csv_import_magic.views.importers.edit.example_of_values') %></header>
           <table>

--- a/lib/csv_import_magic/version.rb
+++ b/lib/csv_import_magic/version.rb
@@ -1,3 +1,3 @@
 module CsvImportMagic
-  VERSION = '0.0.7'.freeze
+  VERSION = '0.0.8'.freeze
 end

--- a/spec/lib/generators/csv_import_magic/views_generator_spec.rb
+++ b/spec/lib/generators/csv_import_magic/views_generator_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe CsvImportMagic::Generators::ViewsGenerator, type: :generator do
 
   specify 'check structure of edit view' do
     edit_content = <<-EOF
-<% columns = @importer.importable_columns(@importer.parser).map { |column| [@importer.source_klass.human_attribute_name(column), column] }.unshift([t('csv_import_magic.views.importers.edit.ignore_column_label'), :ignore]) %>
+<% columns = @importer.importable_columns(@importer.parser).map { |column| [@importer.human_attribute_name(column), column] }.unshift([t('csv_import_magic.views.importers.edit.ignore_column_label'), :ignore]) %>
 
 <h3 class='page-title'>
   <%= t('csv_import_magic.views.importers.edit.title') %>
@@ -83,7 +83,7 @@ RSpec.describe CsvImportMagic::Generators::ViewsGenerator, type: :generator do
           </header>
 
           <% selected = columns.find { |c| c.join(' ').match(/#\{header\}/i) }.try(:last).presence || :ignore %>
-          <%= f.input "columns][", as: :select, collection: columns, label: false, hint: t('csv_import_magic.views.importers.edit.hint'), include_blank: false, selected: f.object.columns[i] || selected %>
+          <%= f.input "columns[]", as: :select, collection: columns, label: false, hint: t('csv_import_magic.views.importers.edit.hint'), include_blank: false, selected: f.object.columns[i] || selected %>
 
           <header class="examples"><%= t('csv_import_magic.views.importers.edit.example_of_values') %></header>
           <table>

--- a/spec/models/importer_spec.rb
+++ b/spec/models/importer_spec.rb
@@ -79,4 +79,22 @@ RSpec.describe Importer, type: :model do
     let(:importer) { create(:importer, source: 'company') }
     it { expect(importer.importable_columns).to match_array([:name, :street, :number, :neighborhood, :city, :state, :country]) }
   end
+
+  context '#human_attribute_name' do
+    let(:importer) { create(:importer, source: 'company') }
+    column = 'name'
+    context 'without a translation set' do
+      it 'defaults to source_klass human_attribute_name' do
+        expect(importer.human_attribute_name(column)).to eq(importer.source_klass.human_attribute_name(column))
+      end
+    end
+
+    context 'with a translation set' do
+      it 'returns scoped translation' do
+        allow(I18n).to receive(:translate)
+        allow(I18n).to receive(:translate).with(:"activemodel.attributes.company.csv_import_magic.name", default: importer.source_klass.human_attribute_name(column)).and_return('scoped transalation')
+        expect(importer.human_attribute_name(column)).to eq('scoped transalation')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What?**
This PR adds the capability to use a scoped translation to `csv_import_magic` for each attribute.

**Why?**
Enabling different display names for attributes than the default ones makes it easier to customize the view without having to edit it.

**How?**
Adding a `human_attribute_name` for the gem scope, that defaults to the `source_klass`'s one.